### PR TITLE
Require open to stake

### DIFF
--- a/contracts/stake/stake.cpp
+++ b/contracts/stake/stake.cpp
@@ -183,8 +183,8 @@ void stake::claim(name owner) {
   double avg = (((age_last + age_new) / 2.0) * min_part) + (age_new * max_part);
   uint64_t claim_amount = (stakes.amount.amount * aged * avg) / (double) config.scale_factor;
 
+  print("claiming ", claim_amount, " for age ", (uint64_t) age_new);
 
-  print("claiming ", claim_amount, " for age ", age_new);
 
   stakes_tbl.modify(stakes, eosio::same_payer, [&](auto& a)
                                                {

--- a/contracts/stake/stake.cpp
+++ b/contracts/stake/stake.cpp
@@ -1,7 +1,7 @@
 #include "stake.hpp"
 
-void stake::init(name token_contract, symbol_code stake_symbol,
-                 symbol_code claim_symbol, uint32_t age_limit,
+void stake::init(name token_contract, const symbol& stake_symbol,
+                 const symbol& claim_symbol, uint32_t age_limit,
                  uint64_t scale_factor, uint32_t unstake_delay_sec) {
   require_auth(get_self());
 
@@ -33,7 +33,7 @@ void stake::transfer_handler(name from, name to, asset quantity, std::string mem
     config_table config_tbl(_self, _self.value);
     eosio::check(config_tbl.exists(), "not initialized");
     auto config = config_tbl.get();
-    eosio::check(config.stake_symbol == sym.code(), "asset cant be staked");
+    eosio::check(config.stake_symbol == sym, "asset cant be staked");
 
     // validate the contract that is staking
     eosio::check(config.token_contract == get_code(), "contract is not allowed to stake");
@@ -41,15 +41,17 @@ void stake::transfer_handler(name from, name to, asset quantity, std::string mem
     stake_table stakes_tbl(get_self(), from.value);
     auto stakes = stakes_tbl.find(sym.code().raw());
 
-    if (stakes == stakes_tbl.end()) {
+    eosio::check(stakes != stakes_tbl.end(), "you must open a stake before staking");
+
+    if (stakes->amount.amount == 0) {
       // this is a new stake
-      stakes_tbl.emplace(get_self(),
-                         [&](auto& st)
-                         {
-                           st.amount = quantity;
-                           st.last_claim_time = time_point_sec(now());
-                           st.last_claim_age = 0;
-                         });
+      stakes_tbl.modify(stakes, eosio::same_payer,
+                        [&](auto& st)
+                        {
+                          st.amount = quantity;
+                          st.last_claim_time = time_point_sec(now());
+                          st.last_claim_age = 0;
+                        });
     } else {
       // dilute an existing stake; a claim is mandatory
       eosio::check(stakes->last_claim_time == time_point_sec(now()),
@@ -66,6 +68,27 @@ void stake::transfer_handler(name from, name to, asset quantity, std::string mem
                         });
     }
   }
+}
+
+void stake::open(name owner, name ram_payer) {
+   require_auth(ram_payer);
+
+   config_table config_tbl(_self, _self.value);
+   eosio::check(config_tbl.exists(), "not initialized");
+   auto config = config_tbl.get();
+
+   auto symbol = config.stake_symbol;
+
+   stake_table stakes_tbl(get_self(), owner.value);
+   auto stakes = stakes_tbl.find(symbol.code().raw());
+   if(stakes == stakes_tbl.end() ) {
+      stakes_tbl.emplace(ram_payer, [&](auto& a)
+                                    {
+                                      a.amount = eosio::asset{0, symbol};
+                                      a.last_claim_time = time_point_sec(now());
+                                      a.last_claim_age = 0;
+                                    });
+   }
 }
 
 void stake::unstake(name owner, asset quantity) {
@@ -115,7 +138,7 @@ void stake::refund(name owner) {
   auto config = config_tbl.get();
 
   unstake_table unstake_tbl(get_self(), owner.value);
-  const auto& unstakes = unstake_tbl.get(config.stake_symbol.raw(), "no unstake exists");
+  const auto& unstakes = unstake_tbl.get(config.stake_symbol.code().raw(), "no unstake exists");
 
   auto unstake_at = unstakes.time + config.unstake_delay_sec;
 
@@ -132,19 +155,17 @@ void stake::refund(name owner) {
          ).send();
 }
 
-void stake::claim(name owner, symbol_code token) {
+void stake::claim(name owner) {
   require_auth(owner);
-
-  eosio::check(token.is_valid(), "invalid symbol name");
-
-  stake_table stakes_tbl(get_self(), owner.value);
-  const auto& stakes_chk = stakes_tbl.find(token.raw());
-  eosio::check(stakes_chk != stakes_tbl.end(), "stake does not exist");
-  const auto& stakes = *stakes_chk;
 
   config_table config_tbl(_self, _self.value);
   eosio::check(config_tbl.exists(), "not initialized");
   auto config = config_tbl.get();
+
+  stake_table stakes_tbl(get_self(), owner.value);
+  const auto& stakes_chk = stakes_tbl.find(config.stake_symbol.code().raw());
+  eosio::check(stakes_chk != stakes_tbl.end(), "stake does not exist");
+  const auto& stakes = *stakes_chk;
 
   // calculate the new and old stake age
   auto cur = time_point_sec(now());
@@ -172,12 +193,10 @@ void stake::claim(name owner, symbol_code token) {
                                                  a.last_claim_age = age_new;
                                                });
 
-  symbol sym = symbol(config.claim_symbol, 4);
-
   action(permission_level{_self, "active"_n},
          config.token_contract,
          "issue"_n,
-         std::make_tuple(owner, asset(claim_amount, sym), CLAIM_MEMO)
+         std::make_tuple(owner, asset(claim_amount, config.claim_symbol), CLAIM_MEMO)
          ).send();
 }
 
@@ -187,7 +206,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
                           &stake::transfer_handler);
   } else if (code == receiver) {
     switch(action) {
-      EOSIO_DISPATCH_HELPER(stake, (init)(unstake)(refund)(claim));
+      EOSIO_DISPATCH_HELPER(stake, (init)(open)(unstake)(refund)(claim));
     }
   }
 }

--- a/contracts/stake/stake.cpp
+++ b/contracts/stake/stake.cpp
@@ -183,7 +183,6 @@ void stake::claim(name owner) {
   double avg = (((age_last + age_new) / 2.0) * min_part) + (age_new * max_part);
   uint64_t claim_amount = (stakes.amount.amount * aged * avg) / (double) config.scale_factor;
 
-  eosio::check(claim_amount > 0, "nothing to claim");
 
   print("claiming ", claim_amount, " for age ", age_new);
 
@@ -191,13 +190,15 @@ void stake::claim(name owner) {
                                                {
                                                  a.last_claim_time = cur;
                                                  a.last_claim_age = age_new;
-                                               });
+                                                 });
 
-  action(permission_level{_self, "active"_n},
-         config.token_contract,
-         "issue"_n,
-         std::make_tuple(owner, asset(claim_amount, config.claim_symbol), CLAIM_MEMO)
-         ).send();
+    if (claim_amount > 0) {
+      action(permission_level{_self, "active"_n},
+             config.token_contract,
+             "issue"_n,
+             std::make_tuple(owner, asset(claim_amount, config.claim_symbol), CLAIM_MEMO)
+             ).send();
+    }
 }
 
 extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {

--- a/contracts/stake/stake.hpp
+++ b/contracts/stake/stake.hpp
@@ -23,8 +23,8 @@ class [[eosio::contract("stake")]] stake : public contract {
 
   [[eosio::action]]
     void init(name token_contract,
-              symbol_code stake_symbol,
-              symbol_code claim_symbol,
+              const symbol& stake_symbol,
+              const symbol& claim_symbol,
               uint32_t age_limit,
               uint64_t scale_factor,
               uint32_t unstake_delay_sec);
@@ -37,16 +37,19 @@ class [[eosio::contract("stake")]] stake : public contract {
     void refund(name owner);
 
   [[eosio::action]]
-    void claim(name owner,
-               symbol_code token);
+    void open(name owner,
+              name ram_payer);
+
+  [[eosio::action]]
+    void claim(name owner);
 
   void transfer_handler(name from, name to, asset quantity, std::string memo);
 
  private:
   struct [[eosio::table]] config {
     name token_contract;
-    symbol_code stake_symbol;
-    symbol_code claim_symbol;
+    symbol stake_symbol;
+    symbol claim_symbol;
     uint32_t age_limit;
     uint64_t scale_factor;
     uint32_t unstake_delay_sec;

--- a/deploy/jungle.cljs
+++ b/deploy/jungle.cljs
@@ -7,9 +7,23 @@
 
 (def token-acc "forbeginners")
 (def swap-acc "dontworrybet")
-(def symb "ABC")
+(def stake-acc "upandrunning")
 (def bk-acc "foreveryoung")
-(def total-supply "650000000.0000")
+
+(def tkn-sym "TKN")
+(def clm-sym "CLM")
+(def tkn-total-supply "650000000.0000")
+(def clm-total-supply "20000000000.0000")
+
+(def sec-per-day 86400)
+
+(def stake-config {:token_contract token-acc :stake_symbol tkn-sym
+                   :claim_symbol clm-sym :age_limit (* 200 sec-per-day)
+                   :scale_factor (*  1000000 sec-per-day)
+                   :unstake_delay_sec (* 7 sec-per-day)})
+
+(def swap-config {:token_contract token-acc :token_symbol tkn-sym
+                  :issue_memo (str "Welcome to EOS " tkn-sym "!")})
 
 (defn usage [opts]
   (->> ["Run as `npm run deploy jungle <PRIVATE KEY FOR SIGNING>`"
@@ -19,6 +33,9 @@
         "Code will be deployed to:"
         (str "- " token-acc " (token)")
         (str "- " swap-acc " (swap)")
+        (str "- " stake-acc " (stake)")
+        ""
+        (str bk-acc " is a book keeper which is allowed to posttx")
         ""]
        (string/join "\n")))
 
@@ -28,22 +45,45 @@
     (let [[privatekey] *command-line-args*]
       (eos/set-api! (assoc (:jungle eos/apis) :priv-keys [privatekey]))
       (->
-       ;; set authorities
-       (eos/update-auth swap-acc "active"
-                        [{:permission
-                          {:actor swap-acc :permission "eosio.code"}
-                          :weight 1}])
        ;; deploy fresh code
-       (.then #(eos/deploy token-acc "contracts/effect-token/src/effect-token"))
+       (eos/deploy token-acc "contracts/effect-token/effect-token")
        (.catch prn)
        (.then #(eos/deploy swap-acc "contracts/swap/swap"))
        (.catch prn)
+       (.then #(eos/deploy stake-acc "contracts/stake/stake"))
+       (.catch prn)
+       ;; set authorities
+       (.then
+        #(eos/update-auth swap-acc "active"
+                          [{:permission
+                            {:actor swap-acc :permission "eosio.code"}
+                            :weight 1}]))
+       (.then
+        #(eos/update-auth stake-acc "active"
+                          [{:permission
+                            {:actor stake-acc :permission "eosio.code"}
+                            :weight 1}]))
        eos/wait-block
        ;; create the token
-       (.then  (print "\n========================\nCREATE TOKEN" symb
+       (.then #(print "\n========================\nCREATE TOKEN" tkn-sym
                       " in " token-acc "\n========================\n"))
-       (.then #(eos/transact token-acc "create"
-                             {:issuer swap-acc :maximum_supply (str total-supply symb)}))
+       (.then
+        #(eos/transact token-acc "create"
+                       {:issuer swap-acc :maximum_supply (str tkn-total-supply " " tkn-sym)}))
+       (.catch prn)
+       (.then #(prn  (str clm-total-supply " " clm-sym) "xxxx"))
+       (.then
+        #(eos/transact token-acc "create"
+                       {:issuer stake-acc :maximum_supply (str clm-total-supply " " clm-sym)}))
+       (.catch prn)
+       ;; initialize stake and swap
+       (.then
+        #(eos/transact stake-acc "init" stake-config
+                       [{:actor stake-acc :permission "owner"}]))
+       (.catch prn)
+       (.then
+        #(eos/transact swap-acc "init" swap-config
+                       [{:actor swap-acc :permission "owner"}]))
        (.catch prn)
        ;; add a bookkeeper that can post neo txs
        (.then #(eos/transact swap-acc "mkbookkeeper" {:account bk-acc}

--- a/deploy/jungle.cljs
+++ b/deploy/jungle.cljs
@@ -17,8 +17,8 @@
 
 (def sec-per-day 86400)
 
-(def stake-config {:token_contract token-acc :stake_symbol tkn-sym
-                   :claim_symbol clm-sym :age_limit (* 200 sec-per-day)
+(def stake-config {:token_contract token-acc :stake_symbol (str "4," tkn-sym)
+                   :claim_symbol (str "4," clm-sym) :age_limit (* 200 sec-per-day)
                    :scale_factor (*  1000000 sec-per-day)
                    :unstake_delay_sec (* 7 sec-per-day)})
 
@@ -71,7 +71,6 @@
         #(eos/transact token-acc "create"
                        {:issuer swap-acc :maximum_supply (str tkn-total-supply " " tkn-sym)}))
        (.catch prn)
-       (.then #(prn  (str clm-total-supply " " clm-sym) "xxxx"))
        (.then
         #(eos/transact token-acc "create"
                        {:issuer stake-acc :maximum_supply (str clm-total-supply " " clm-sym)}))

--- a/deploy/jungle.cljs
+++ b/deploy/jungle.cljs
@@ -19,7 +19,7 @@
 
 (def stake-config {:token_contract token-acc :stake_symbol (str "4," tkn-sym)
                    :claim_symbol (str "4," clm-sym) :age_limit (* 200 sec-per-day)
-                   :scale_factor (*  1000000 sec-per-day)
+                   :scale_factor (* 10000000000 sec-per-day)
                    :unstake_delay_sec (* 7 sec-per-day)})
 
 (def swap-config {:token_contract token-acc :token_symbol tkn-sym


### PR DESCRIPTION
- adds an open action to create an empty stake entry
- staking updates the old entry, so user pays for ram
- store symbol instead of symbol_code in stake config