### PR TITLE
Add stake age bonus

### DIFF
--- a/contracts/stake/stake.hpp
+++ b/contracts/stake/stake.hpp
@@ -27,7 +27,9 @@ class [[eosio::contract("stake")]] stake : public contract {
               const symbol& claim_symbol,
               uint32_t age_limit,
               uint64_t scale_factor,
-              uint32_t unstake_delay_sec);
+              uint32_t unstake_delay_sec,
+              uint32_t stake_bonus_age,
+              time_point_sec stake_bonus_deadline);
 
   [[eosio::action]]
     void unstake(name owner,
@@ -53,6 +55,8 @@ class [[eosio::contract("stake")]] stake : public contract {
     uint32_t age_limit;
     uint64_t scale_factor;
     uint32_t unstake_delay_sec;
+    uint32_t stake_bonus_age;
+    time_point_sec stake_bonus_deadline;
   };
 
   struct [[eosio::table]] stakeentry {

--- a/deploy/jungle.cljs
+++ b/deploy/jungle.cljs
@@ -20,7 +20,9 @@
 (def stake-config {:token_contract token-acc :stake_symbol (str "4," tkn-sym)
                    :claim_symbol (str "4," clm-sym) :age_limit (* 200 sec-per-day)
                    :scale_factor (* 10000000000 sec-per-day)
-                   :unstake_delay_sec (* 7 sec-per-day)})
+                   :unstake_delay_sec (* 7 sec-per-day)
+                   :stake_bonus_age (* 50 sec-per-day)
+                   :stake_bonus_deadline "2019-04-18T15:59:44.500"})
 
 (def swap-config {:token_contract token-acc :token_symbol tkn-sym
                   :issue_memo (str "Welcome to EOS " tkn-sym "!")})

--- a/tests/e2e/stake.cljs
+++ b/tests/e2e/stake.cljs
@@ -68,8 +68,10 @@
    :after (fn [])})
 
 (def init-config {:token_contract token-acc :stake_symbol (str "4," sym)
-                  :claim_symbol (str "4," claim-sym) :age_limit 5
-                  :scale_factor (*  1000000 1) :unstake_delay_sec 2})
+                  :claim_symbol (str "4," claim-sym) :age_limit 65
+                  :scale_factor (*  1000000 1) :unstake_delay_sec 2
+                  :stake_bonus_age 60
+                  :stake_bonus_deadline "2019-05-18T14:37:30"})
 
 (deftest initialize
   (async


### PR DESCRIPTION
If you stake tokens before a certain deadline users will receive a bonus stake age. For this 2 new config variables are added:
 
1. `stake_bonus_deadline`: deadline of the stake age bonus period (time_point_sec)
2. `stake_bonus_age`: the bonus stake age in seconds

The bonus is also taken into account when topping up a stake