### PR TITLE
Stake updates

### DIFF
--- a/contracts/swap/swap.hpp
+++ b/contracts/swap/swap.hpp
@@ -13,9 +13,6 @@ using namespace eosio;
 
 class [[eosio::contract("swap")]] swap : public contract {
  public:
-  static const int64_t MIN_TX_VALUE = 0;
-  static const int64_t MAX_TX_VALUE = 10000000000;
-
   swap(eosio::name receiver, eosio::name code, eosio::datastream<const char*> ds) :
     eosio::contract(receiver, code, ds), _nep5(_self, _self.value),
     _bookkeeper(_self, _self.value) {};
@@ -24,7 +21,9 @@ class [[eosio::contract("swap")]] swap : public contract {
     void init(name token_contract,
               symbol_code token_symbol,
               std::string issue_memo,
-              uint32_t tx_max_age);
+              uint32_t tx_max_age,
+              uint64_t min_tx_value,
+              uint64_t max_tx_value);
 
   [[eosio::action]]
     void posttx(name bookkeeper,
@@ -50,6 +49,8 @@ class [[eosio::contract("swap")]] swap : public contract {
     symbol_code token_symbol;
     std::string issue_memo;
     uint32_t tx_max_age;
+    uint64_t min_tx_value;
+    uint64_t max_tx_value;
   };
 
   struct [[eosio::table]] nep5 {

--- a/deploy/jungle.cljs
+++ b/deploy/jungle.cljs
@@ -1,6 +1,6 @@
 (ns jungle
   (:require
-   [eos-deploys.core :as eos]
+   [eos-cljs.core :as eos]
    [cljs.core :refer [*command-line-args*]]
    [clojure.string :as string]
    (clojure.pprint :refer [pprint])))
@@ -25,7 +25,9 @@
                    :stake_bonus_deadline "2019-04-18T15:59:44.500"})
 
 (def swap-config {:token_contract token-acc :token_symbol tkn-sym
-                  :issue_memo (str "Welcome to EOS " tkn-sym "!")})
+                  :issue_memo (str "Welcome to EOS " tkn-sym "!")
+                  :tx_max_age 10000
+                  :min_tx_value 1 :max_tx_value 100000})
 
 (defn usage [opts]
   (->> ["Run as `npm run deploy jungle <PRIVATE KEY FOR SIGNING>`"

--- a/tests/e2e/swap.cljs
+++ b/tests/e2e/swap.cljs
@@ -59,7 +59,8 @@
                  permission)))
 
 (def init-config {:token_contract token-acc :token_symbol sym
-                  :issue_memo "Token Swap" :tx_max_age 100000000})
+                  :issue_memo "Token Swap" :tx_max_age 100000000
+                  :min_tx_value 1 :max_tx_value "10000000000"})
 
 (deftest initialize
   (async

--- a/tests/e2e/swap.cljs
+++ b/tests/e2e/swap.cljs
@@ -32,9 +32,7 @@
               (->
                (eos/create-account owner-acc swap-acc)
                (.then #(eos/create-account owner-acc bk-acc))
-               (.catch prn)
                (.then #(println (str "> Created SWAP account " swap-acc)))
-               eos/wait-block
                (.then #(eos/deploy swap-acc "contracts/swap/swap"))
                (.catch prn)
                (.then #(eos/update-auth swap-acc "active"
@@ -42,7 +40,6 @@
                                           :weight 1}
                                          {:permission {:actor owner-acc :permission "active"}
                                           :weight 1}]))
-               eos/wait-block
                (.then #(eos/transact token-acc "create"
                                      {:issuer swap-acc :maximum_supply total-supply}))
                (.catch prn)
@@ -80,7 +77,6 @@
     (.then #(eos/transact swap-acc "init" init-config))
     (util/should-succeed "can perform init")
     (.then #(eos/get-table-rows swap-acc swap-acc "config"))
-
     (.then #(is (= (vals (first %)) (vals init-config)) "config incorrect"))
     eos/wait-block
     ;; cant set config twice


### PR DESCRIPTION
- instead of failing when a transfer comes from an unknown contract, let
the transfer go through without staking.