### PR TITLE
Implement network fees in force

### DIFF
--- a/contracts/force/force.cpp
+++ b/contracts/force/force.cpp
@@ -485,7 +485,8 @@ void force::closebatch(uint64_t batch_id, vaccount::vaddress owner, vaccount::si
 
   eosio::check(camp.owner == owner, "Only campaign owner can pause batch.");
   vaccount::require_auth(pack(params), owner, sig);
-  eosio::check(batch.tasks_done >= 0 && batch.num_tasks > 0 && batch.tasks_done < batch.num_tasks,
+  eosio::check(batch.tasks_done >= 0 && batch.num_tasks > 0 &&
+               batch.tasks_done < batch.num_tasks * batch.repetitions,
                "can only pause batches with active tasks.");
 
   batch_tbl.modify(batch, eosio::same_payer, [&](auto& b) { b.num_tasks = 0; });

--- a/deploy/mainnet.cljs
+++ b/deploy/mainnet.cljs
@@ -78,7 +78,14 @@
                                    :type "vtransfer"}
                                   [{:actor force-acc :permission "active"}]))
 
-      (<p! (eos/transact force-acc "init" {:vaccount_contract vaccount-acc
-                                           :force_vaccount_id 0
-                                           :payout_delay_sec 1800
-                                           :release_task_delay_sec 1800})))))
+      (<p-may-fail! (eos/transact "eosio" "linkauth"
+                                  {:account force-acc
+                                   :requirement "xfer"
+                                   :code vaccount-acc
+                                   :type "withdraw"}
+                                  [{:actor force-acc :permission "active"}]))
+
+      (<p! (eos/transact force-acc "migrate" {:payer force-acc
+                                              :fee_percentage 0.1
+                                              :fee_contract "feepool.efx"
+                                              :release_task_delay_sec 1800})))))

--- a/tests/e2e/macros.cljc
+++ b/tests/e2e/macros.cljc
@@ -36,8 +36,8 @@
        (cljs.test/is true ~msg)
        res#)
      (catch js/Error e#
-       (prn "test failed with " e#)
-       (cljs.test/is nil ~msg))))
+       (let [err# (.-message (.-cause e#))]
+         (cljs.test/is (= "succeeded" err#) ~msg)))))
 
 (defmacro async-deftest [name & body]
   `(~'deftest ~name

--- a/tests/e2e/vaccount.cljs
+++ b/tests/e2e/vaccount.cljs
@@ -101,10 +101,10 @@
 
 (def keypair (.genKeyPair ec))
 (def keypair-pub (hex->bytes (.encodeCompressed (.getPublic keypair) "hex")))
-(prn "KeyPair Public 1 = " (.getPublic keypair "hex"))
-(prn "KeyPair Private 1 = " (.getPrivate keypair "hex"))
+;; (prn "KeyPair Public 1 = " (.getPublic keypair "hex"))
+;; (prn "KeyPair Private 1 = " (.getPrivate keypair "hex"))
 
-(prn "KeyPair Compressed 1 = " (.encodeCompressed (.getPublic keypair) "hex"))
+;; (prn "KeyPair Compressed 1 = " (.encodeCompressed (.getPublic keypair) "hex"))
 
 ;; To check the Hex value of account names
 ;; (prn "DEBUG hex: " (bytes->hex (name->bytes owner-acc)))


### PR DESCRIPTION
This PR:

- Add new settings: 
  - `fee_percentage`: the percentage of the fee that will be paid per task
  - `fee_contract`: the EOS account that fees will be sent to
   
- Implements a network fee on publish batch. The fee amount is `fee_percentage` of the total batch price. The network fee is "withdrawn" from the contract vAccount balance to an EOS account.

- Converts the `config` table to a new `settings` table and migrates the data over. This is because `config` was a singleton from CDT which does not support binary extensions. As singleton is a very light wrapper for a 1-row table I decided to replicate this functionality in this contract with support with binary extensions.

There is a short amount of time where some contract instructions will stop working (until migrate has completed). During this time `publishbatch` and `reclaimtask` will give a message that the platform is in maintenance.

**Important**: all dApps will have to update to a new version of `effect-js` in order to account for the fees when publishing new batches.