### PR TITLE
dao: Allow execution of proposals without a reward

### DIFF
--- a/contracts/proposals/proposals.cpp
+++ b/contracts/proposals/proposals.cpp
@@ -349,12 +349,14 @@ void proposals::executeprop(uint64_t id) {
 
     eosio::check(lock <= time_point_sec(now()), "payment is still locked");
 
-    action(permission_level{_self, "dao"_n},
-           asset.contract,
-           "transfer"_n,
-           std::make_tuple(_self, prop.author, asset.quantity,
-                           "proposal " + std::to_string(prop.id)))
-      .send();
+    if (asset.quantity.amount > 0) {
+      action(permission_level{_self, "dao"_n},
+             asset.contract,
+             "transfer"_n,
+             std::make_tuple(_self, prop.author, asset.quantity,
+                             "proposal " + std::to_string(prop.id)))
+        .send();
+    }
   }
 }
 

--- a/deploy/mainnet20230115.cljs
+++ b/deploy/mainnet20230115.cljs
@@ -1,0 +1,29 @@
+(ns mainnet20230115
+  (:require
+   [eos-cljs.core :as eos]
+   [cljs.core :refer [*command-line-args*]]
+   [clojure.string :as string]
+   [clojure.pprint :refer [pprint]]
+   [cljs.core.async.interop :refer [<p!]]
+   [cljs.core.async :refer [go] :as async]
+
+   [eos-cljs.node-api :as eos-node :refer [deploy-file]]
+   [eos-cljs.macros :refer-macros [<p-may-fail!]]))
+
+(def token-acc "effecttokens")
+(def vaccount-acc "vaccount.efx")
+(def force-acc "force.efx")
+(def feepool-acc "feepool.efx")
+(def prop-acc "daoproposals")
+(def dao-acc "theeffectdao")
+
+(def expected-hash "d4ab62fdfec73e954577b0500b2c625d5991c0cee4fb39f25e31e07605c96093")
+(def prop-file "contracts/proposals/proposals")
+
+(defn -main [& args]
+  (let [private-keys *command-line-args*]
+    (eos-node/set-api! :mainnet {:priv-keys private-keys})
+    (go
+      (try
+        (<p! (deploy-file prop-acc prop-file))
+        (catch js/Error e (prn e))))))


### PR DESCRIPTION
previously, 0 reward proposals would fail to execute, because in EOS you can only transfer positive quantities. 0-reward proposals pays were expected to no be entered.

as the DAO UI is posting 0-reward proposals it is better to not execute the inline transfer action for 0-reward pays. this will allow us to still execute inline action